### PR TITLE
Ignore unset pyproject configuration

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -5,11 +5,20 @@ set -euo pipefail
 # shellcheck source-path=.
 source "$RTX_PLUGIN_PATH/bin/utils.sh"
 
-VIRTUAL_ENV="$(poetry_venv)"
-if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
-  echoerr "rtx-poetry: No virtualenv exists. Executing \`poetry install\` to create one."
-  "$(poetry_bin)" install
-  VIRTUAL_ENV="$("$(poetry_bin)" env info --path)"
-fi
-POETRY_ACTIVE=1
-export VIRTUAL_ENV POETRY_ACTIVE
+setup_virtualenv() {
+  VIRTUAL_ENV="$(poetry_venv)"
+  if [[ -z "$VIRTUAL_ENV" ]]; then
+    return
+  fi
+
+  if [[ ! -d $VIRTUAL_ENV ]]; then
+    echoerr "rtx-poetry: No virtualenv exists. Executing \`poetry install\` to create one."
+    "$(poetry_bin)" install
+    VIRTUAL_ENV="$("$(poetry_bin)" env info --path)"
+  fi
+
+  POETRY_ACTIVE=1
+  export VIRTUAL_ENV POETRY_ACTIVE
+}
+
+setup_virtualenv


### PR DESCRIPTION
Handles the case where the `pyproject` configuration is not set, preventing a virtual environment from being created unexpectedly. 