### PR TITLE
Explicitly specify project root for poetry

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -17,8 +17,8 @@ setup_virtualenv() {
       return
     fi
     echoerr "mise-poetry: No virtualenv exists. Executing \`poetry install\` to create one."
-    "$(poetry_bin)" install
-    VIRTUAL_ENV="$("$(poetry_bin)" env info --path)"
+    poetry_bin install
+    VIRTUAL_ENV="$(poetry_bin env info --path)"
   fi
 
   POETRY_ACTIVE=1

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -9,7 +9,7 @@ echoerr() {
 }
 
 poetry_bin() {
-  echo "$MISE_INSTALL_PATH/bin/poetry"
+  "$MISE_INSTALL_PATH/bin/poetry" "$@"
 }
 
 poetry_venv() {
@@ -25,6 +25,6 @@ poetry_venv() {
     echoerr "mise-poetry: No pyproject.toml found. Execute \`poetry init\` to create \`$pyproject\` first."
     return
   fi
-  "$(poetry_bin)" env info --path 2>/dev/null
+  poetry_bin -C "${pyproject%/*}" env info --path 2>/dev/null
   true
 }


### PR DESCRIPTION
Projects with nested `pyproject.toml` may pick up the incorrect file relative to the `.mise(.local)?.toml` if the working directory is deeper than a nested file.

This can lead to a (shared) virtual-environment at the top-level not being activated.

```
project/         <-- VIRTUAL_ENV/POETRY_ACTIVE set as expected
  .mise.toml
  .venv/         <-- shared by sub-projects
  pyproject.toml
  sub-project/   <-- VIRTUAL_ENV/POETRY_ACTIVE not set
    pyproject.toml
```

This change infers the poetry project directory from the `pyproject.toml` file. If virtual-environments are desired for the sub-projects, then a `.mise.toml` can be created in those directories.