### PR TITLE
Fix venv checks before auto installing

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -12,11 +12,7 @@ setup_virtualenv() {
   fi
 
   VIRTUAL_ENV="$(poetry_venv)"
-  if [[ -z "$VIRTUAL_ENV" ]]; then
-    return
-  fi
-
-  if [[ ! -d "$VIRTUAL_ENV" ]]; then
+  if [[ -z "$VIRTUAL_ENV" ]] || [[ ! -d "$VIRTUAL_ENV" ]]; then
     if [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "true" ]] && [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "1" ]]; then
       echoerr "mise-poetry: Virtualenv does not exist at $VIRTUAL_ENV. Execute \`poetry install\` to create one."
       return


### PR DESCRIPTION
Attempt to resolve https://github.com/mise-plugins/mise-poetry/issues/19 where the autoinstallation is never run if `VIRTUAL_ENV` is empty. This seems to always be the case when `poetry install` hasn't been run.

Take care merging this becuase I can't see, with poetry's apparent behaviour, how this ever worked. There might well be something I'm missing. I am using this code locally and it looks good.