### PR TITLE
Use return codes from poetry_venv to disabiguate causes of returns.

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -12,7 +12,9 @@ setup_virtualenv() {
   fi
 
   VIRTUAL_ENV="$(poetry_venv)"
-  if [[ -z "$VIRTUAL_ENV" ]] || [[ ! -d "$VIRTUAL_ENV" ]]; then
+  
+  pyproject="$(eval "echo ${MISE_TOOL_OPTS__PYPROJECT-}")"
+  if [ "$pyproject" != "" ] && ([[ -z "$VIRTUAL_ENV" ]] || [[ ! -d "$VIRTUAL_ENV" ]]); then
     if [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "true" ]] && [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "1" ]]; then
       echoerr "mise-poetry: Virtualenv does not exist at $VIRTUAL_ENV. Execute \`poetry install\` to create one."
       return

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -11,10 +11,16 @@ setup_virtualenv() {
     return
   fi
 
+  set +e
   VIRTUAL_ENV="$(poetry_venv)"
-  
-  pyproject="$(eval "echo ${MISE_TOOL_OPTS__PYPROJECT-}")"
-  if [ "$pyproject" != "" ] && ([[ -z "$VIRTUAL_ENV" ]] || [[ ! -d "$VIRTUAL_ENV" ]]); then
+  poetry_venv_exit_code=$?
+  set -e
+
+  if [[ $poetry_venv_exit_code -eq 2 ]] || [[ -z "$VIRTUAL_ENV" ]]; then
+    return
+  fi
+
+  if [[ ! -d "$VIRTUAL_ENV" ]]; then
     if [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "true" ]] && [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "1" ]]; then
       echoerr "mise-poetry: Virtualenv does not exist at $VIRTUAL_ENV. Execute \`poetry install\` to create one."
       return

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -16,7 +16,7 @@ setup_virtualenv() {
   poetry_venv_exit_code=$?
   set -e
 
-  if [[ $poetry_venv_exit_code -eq 2 ]] || [[ -z "$VIRTUAL_ENV" ]]; then
+  if [[ $poetry_venv_exit_code -eq 2 ]]; then
     return
   fi
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -16,7 +16,7 @@ setup_virtualenv() {
   poetry_venv_exit_code=$?
   set -e
 
-  if [[ $poetry_venv_exit_code -eq 2 ]]; then
+  if [[ $poetry_venv_exit_code -eq 1 ]]; then
     return
   fi
 

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,14 +16,14 @@ poetry_venv() {
   local pyproject
   pyproject="$(eval "echo ${MISE_TOOL_OPTS__PYPROJECT-}")"
   if [ "$pyproject" = "" ]; then
-    return
+    return 2
   fi
   if [[ $pyproject != /* ]] && [[ -n ${MISE_PROJECT_ROOT-} ]]; then
     pyproject="${MISE_PROJECT_ROOT-}/$pyproject"
   fi
   if [[ ! -f $pyproject ]]; then
     echoerr "mise-poetry: No pyproject.toml found. Execute \`poetry init\` to create \`$pyproject\` first."
-    return
+    return 2
   fi
   poetry_bin -C "${pyproject%/*}" env info --path 2>/dev/null
   true

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -16,14 +16,14 @@ poetry_venv() {
   local pyproject
   pyproject="$(eval "echo ${MISE_TOOL_OPTS__PYPROJECT-}")"
   if [ "$pyproject" = "" ]; then
-    return 2
+    return 1
   fi
   if [[ $pyproject != /* ]] && [[ -n ${MISE_PROJECT_ROOT-} ]]; then
     pyproject="${MISE_PROJECT_ROOT-}/$pyproject"
   fi
   if [[ ! -f $pyproject ]]; then
     echoerr "mise-poetry: No pyproject.toml found. Execute \`poetry init\` to create \`$pyproject\` first."
-    return 2
+    return 1
   fi
   poetry_bin -C "${pyproject%/*}" env info --path 2>/dev/null
   true


### PR DESCRIPTION
The issue is that  `setup_virtualenv` in `exec-env` can't tell why `poetry_venv` has exited. There are three reasons to return:

1. if pyproject is not set, venv installation should not happen
2. else if the file doesn't exist venv installation should not happen
3. else if poetry can't show a venv path (it doesn't exist) venv installation should happen if MISE_POETRY_AUTO_INSTALL is set

- I've set cases 1 and 2 to return `1` for detection and graceful exit.
- Case 3 attempts to install if MISE_POETRY_AUTO_INSTALL is set.

The handling of cases 1 and 2 are fixed here to fix https://github.com/mise-plugins/mise-poetry/issues/21