### PR TITLE
Remove unwanted error messages

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -22,10 +22,8 @@ setup_virtualenv() {
 
   if [[ ! -d "$VIRTUAL_ENV" ]]; then
     if [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "true" ]] && [[ "${MISE_POETRY_AUTO_INSTALL:-}" != "1" ]]; then
-      echoerr "mise-poetry: Virtualenv does not exist at $VIRTUAL_ENV. Execute \`poetry install\` to create one."
       return
     fi
-    echoerr "mise-poetry: No virtualenv exists. Executing \`poetry install\` to create one."
     poetry_bin install
     VIRTUAL_ENV="$(poetry_bin env info --path)"
   fi


### PR DESCRIPTION
Remove error messages that are extremely annoying when having configured poetry as a global tool with mise. See the discussion in #23.

Closes #23 