### PR TITLE
add env var to auto activate venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ poetry = {version='latest', pyproject='pyproject.toml'}
 python = '3.11' # must be after poetry so the poetry bin is first in PATH
 ```
 
+You can also set `MISE_POETRY_VENV_AUTO=1` to automatically activate the virtualenv if the  
+project contains both `pyproject.toml` and `poetry.lock` files.
+
 Set `MISE_POETRY_AUTO_INSTALL=1` to automatically run `poetry install` to create the virtualenv.
 
 ## License

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -15,8 +15,14 @@ poetry_bin() {
 poetry_venv() {
   local pyproject
   pyproject="$(eval "echo ${MISE_TOOL_OPTS__PYPROJECT-}")"
-  if [ "$pyproject" = "" ]; then
+  if [[ "${MISE_POETRY_VENV_AUTO:-}" != "true" ]] && [[ "${MISE_POETRY_VENV_AUTO:-}" != "1" ]]; then
+    if [ "$pyproject" = "" ]; then
+      return 1
+    fi
+  elif [[ ! -f "poetry.lock" ]] | [[ ! -f "pyproject.toml" ]]; then
     return 1
+  else
+    pyproject="pyproject.toml"
   fi
   if [[ $pyproject != /* ]] && [[ -n ${MISE_PROJECT_ROOT-} ]]; then
     pyproject="${MISE_PROJECT_ROOT-}/$pyproject"


### PR DESCRIPTION
Added support for `MISE_POETRY_VENV_AUTO`. If the variable is set to "1" or "true," the plugin will attempt to automatically activate the virtual environment. It checks the project for the presence of both `poetry.lock` and `pyproject.toml` files, and if they are found, venv is activated.  