### PR TITLE
fix(poetry): replace deprecated config option for Poetry 2.0.0

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -55,9 +55,9 @@ install_poetry() {
   if [ "$config_vercomp" == "ge" ]; then
     # Ensure that poetry behaves as expected with asdf python (pyenv)
     echo Configuring poetry to behave properly with asdf ...
-    echo Running: \"poetry config virtualenvs.prefer-active-python true\".
+    echo Running: \"poetry config virtualenvs.use-poetry-python true\".
     echo ""
-    "$install_path"/bin/poetry config virtualenvs.prefer-active-python true
+    "$install_path"/bin/poetry config virtualenvs.use-poetry-python true
   else
     echo Warning: Poetry versions prior to 1.2.0 may not work properly with asdf.
     echo Consider upgrading to a later version.


### PR DESCRIPTION
fix(poetry): replace deprecated config option for Poetry 2.0.0

- Replaced 'virtualenvs.prefer-active-python' with 'virtualenvs.use-poetry-python' in the install script.
- This change aligns with Poetry 2.0.0's updated configuration, as discussed in mise-plugins/mise-poetry#27.
- The removal of 'virtualenvs.prefer-active-python' in Poetry 2.0 requires this update to ensure compatibility with the latest version.