### PR TITLE
fix: use sort cmd compatible with Alpine/Busybox

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,7 +14,7 @@ cleanup() {
 }
 
 semver_ge() {
-  printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
+  printf '%s\n%s\n' "$2" "$1" | sort -cV > /dev/null 2>&1
 }
 
 install_poetry() {


### PR DESCRIPTION
Verified on MacOS Sequoia 15.3.2 and alpine:3.21.

Fixes: #34