### PR TITLE
Fix leaking `VIRTUAL_ENV` and `POETRY_ACTIVE` into test environment

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,6 +23,9 @@ for DIR in "${FILES[@]}"; do
   NAME=${DIR#"${BASE_DIR}/"}
   printf '█ %s\n\n' "${NAME}"
 
+  # unset these if they've been set externally
+  unset VIRTUAL_ENV POETRY_ACTIVE
+
   if mise exec -C "${DIR}" -- bats -r "${DIR}"; then
     SUCCESS+=("${NAME}")
   else


### PR DESCRIPTION
When testing locally, having these variables set can cause tests to fail.
This probably doesn't affect tests in CI, though.